### PR TITLE
fix: strategic ability not working on Mac

### DIFF
--- a/src/components/SetupFactions.js
+++ b/src/components/SetupFactions.js
@@ -53,7 +53,7 @@ const SetupFactions = ({ users, setUsers, factionShop, factions, setFactions, se
       socket.emit('change-strat-ability', {
         roomUuid: params.battleuuid,
         userUuid: userUuid,
-        stratAbility: value
+        stratAbility: stratAbility
       })
     }
   }


### PR DESCRIPTION
## Summary
- Fixed bug where Mac users were unable to change their strategic ability on the faction setup screen
- The handler was sending the raw string value instead of the parsed integer to the server
- Safari on Mac handles number input events differently, sometimes sending empty strings or partial values that fail server validation

## Changes
- Updated `handleInputStratAbility` in `SetupFactions.js` to send the parsed `stratAbility` integer instead of the raw `value` string (line 56)

## Test plan
- [ ] Verify Mac users can now change their strategic ability on all browsers (Safari, Chrome, Firefox)
- [ ] Verify Windows/Linux users can still change strategic ability without regression
- [ ] Test with various input methods (typing, arrow keys, increment/decrement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)